### PR TITLE
Update exposed-swagger-ui.bcheck

### DIFF
--- a/other/exposed-swagger-ui.bcheck
+++ b/other/exposed-swagger-ui.bcheck
@@ -83,7 +83,7 @@ run for each:
 given host then
   send request called checkSwagger:
     method: "GET"
-    appending path: {potential_path}
+    replacing path: {potential_path}
     headers:
       "Accept": "text/html"
 


### PR DESCRIPTION
Replace the action keyword "appending path" with "replacing path" to make the rule obvious as intended.