### PR TITLE
Added Endpoint Detection Checks

### DIFF
--- a/other/files/configs/git-config-discovery.bcheck
+++ b/other/files/configs/git-config-discovery.bcheck
@@ -1,0 +1,23 @@
+metadata:
+    language: v1-beta
+    name: "Git Configuration Check"
+    description: "Tests for exposed git config in current path as opposed to just root directory of site."
+    author: "github.com/BuffaloWill"
+    tags: "exposure", "git", "config", "file"
+
+run for each:
+    potential_path =
+        ".git/config",
+        ".git/config~"
+
+given request then
+    send request called check:
+        method: "GET"
+        replacing path: `{regex_replace({regex_replace({base.request.url},"^.*?\/.*?\/.*?\/","/")},"([^/]+)$", "")}{potential_path}`
+
+    if "[core]" in {check.response.body} then
+        report issue:
+            severity: low
+            confidence: tentative
+			detail: `Git configuration found at {potential_path}.`
+	end if

--- a/other/files/configs/php-info.discovery.bcheck
+++ b/other/files/configs/php-info.discovery.bcheck
@@ -1,0 +1,44 @@
+metadata:
+    language: v1-beta
+    name: "PHP Info Exposure"
+    description: "PHPinfo page was detected. The output of the phpinfo() command can reveal sensitive and detailed PHP environment information."
+    author: "@puzzlepeaches"
+    tags: "exposure", "php", "info" 
+
+run for each:
+    potential_path =
+      "/php.php",
+      "/phpinfo.php",
+      "/info.php",
+      "/infophp.php",
+      "/php_info.php",
+      "/test.php",
+      "/i.php",
+      "/asdf.php",
+      "/pinfo.php",
+      "/phpversion.php",
+      "/time.php",
+      "/index.php",
+      "/temp.php",
+      "/old_phpinfo.php",
+      "/infos.php",
+      "/linusadmin-phpinfo.php",
+      "/php-info.php",
+      "/dashboard/phpinfo.php",
+      "/_profiler/phpinfo.php",
+      "/_profiler/phpinfo",
+      "/?phpinfo=1"
+
+given request then
+    send request called check:
+        method: "GET"
+        replacing path: `{regex_replace({regex_replace({base.request.url},"^.*?\/.*?\/.*?\/","/")},"([^/]+)$", "")}{potential_path}`
+
+    if "PHP Extension" in {check.response.body} or "PHP Version" in {check.response.body} and
+        {check.response.status_code} is "200" then
+        report issue:
+            severity: low
+            confidence: firm 
+			detail: `PHP info page was found at {check.response.url}`
+            remediation: "Remove PHP Info pages from publicly accessible locations, or restrict access to authorized users only."
+	end if

--- a/other/files/configs/web-config.discovery.bcheck
+++ b/other/files/configs/web-config.discovery.bcheck
@@ -1,0 +1,25 @@
+metadata:
+    language: v1-beta
+    name: "web.config file exposure"
+    description: "IIS Web configuration file was detected."
+    author: "@puzzlepeaches"
+    tags: "exposure", "web", "config", "iis"
+
+run for each:
+    potential_path =
+        "/web.config",
+        "/app/web.config",
+        "/../../web.config"
+
+given request then
+    send request called check:
+        method: "GET"
+        replacing path: `{regex_replace({regex_replace({base.request.url},"^.*?\/.*?\/.*?\/","/")},"([^/]+)$", "")}{potential_path}`
+
+    if {check.response.status_code} is "200" and
+        {check.response.body} matches "<configuration>" and {check.response.body} matches "<system.webServer>" then
+        report issue:
+            severity: low
+            confidence: certain 
+			detail: `IIS Web configuration file was detected at {check.response.url}`
+	end if

--- a/other/files/npm-debug-log.bcheck
+++ b/other/files/npm-debug-log.bcheck
@@ -1,0 +1,27 @@
+metadata:
+  language: v1-beta
+  name: "NPM Debug Log Files"
+  description: "Checks for NPM debug log files in current path as opposed to just root directory of site."
+  author: "@puzzlepeaches"
+  tags: "npm", "log", "exposure", "error"
+
+run for each:
+  potential_path = 
+    "/npm-debug.log",
+    "/assets/npm-debug.log"
+
+
+given request then
+  send request called check:
+    method: "GET"
+    replacing path: `{regex_replace({regex_replace({base.request.url},"^.*?\/.*?\/.*?\/","/")},"([^/]+)$", "")}{potential_path}`
+    
+  if {check.response.body} matches "verbose cli" or
+    {check.response.body} matches "verbose stack" and
+    {check.response.status_code} is "200" then
+    report issue:
+      severity: low
+      confidence: tentative
+      detail: `NPM debug log file found at {potential_path}.`
+  end if
+

--- a/other/files/python-common.bcheck
+++ b/other/files/python-common.bcheck
@@ -1,0 +1,41 @@
+metadata:
+  language: v1-beta
+  name: "Common Python file exposures."
+  description: "Checks for common Python files that may be exposed."
+  author: "@puzzlepeaches"
+  tags: "python", "file", "exposure" 
+
+run for each:
+  potential_path = 
+    "/Pipfile",
+    "/pyproject.toml",
+    "Pipfile.lock"
+
+
+given request then
+  send request called check:
+    method: "GET"
+    replacing path: `{regex_replace({regex_replace({base.request.url},"^.*?\/.*?\/.*?\/","/")},"([^/]+)$", "")}{potential_path}`
+    
+  if {check.response.status_code} is "200" and
+    "[[source]]" in {check.response.body} or "[packages]" in {check.response.body} or "[dev-packages]" in {check.response.body} then
+    report issue:
+      severity: low
+      confidence: firm 
+      detail: `Python Pipfile exposed at {check.response.url}`
+  
+    else if {check.response.status_code} is "200" and
+    "[tool.poetry]" in {check.response.body} or "[tool.poetry.dependencies]" in {check.response.body} or "[tool.poetry.dev-dependencies]" in {check.response.body} then
+    report issue:
+      severity: low
+      confidence: firm 
+      detail: `Python pyproject.toml exposed at {check.response.url}`
+     
+    else if {check.response.status_code} is "200" and
+    "pipfile-spec" in {check.response.body} and "requires" in {check.response.body} then
+    report issue:
+      severity: low
+      confidence: firm 
+      detail: `Python Pipfile.lock exposed at {check.response.url}` 
+  end if
+

--- a/other/files/ruby-on-rails-storage.bcheck
+++ b/other/files/ruby-on-rails-storage.bcheck
@@ -1,0 +1,30 @@
+metadata:
+  language: v1-beta
+  name: "Ruby on Rails storage.yml File Disclosure"
+  description: "Checks for Ruby on Rails storage.yml file disclosure."
+  author: "@puzzlepeaches"
+  tags: "ruby", "storage", "exposure", "rails"
+
+run for each:
+  potential_path = 
+    "/storage.yml",
+    "/config/storage.yml",
+    "/ruby/config/storage.yml",
+    "/railsapp/config/storage.yml"
+
+
+given request then
+  send request called check:
+    method: "GET"
+    replacing path: `{regex_replace({regex_replace({base.request.url},"^.*?\/.*?\/.*?\/","/")},"([^/]+)$", "")}{potential_path}`
+    
+  if {check.response.body} matches "service:" or
+    {check.response.body} matches "local:" and
+    {check.response.status_code} is "200" and
+    not({check.response.headers} matches "text/html" or {check.response.headers} matches "application/json") then
+    report issue:
+      severity: low
+      confidence: firm 
+      detail: `Ruby on Rails storage.yml file disclosure.`
+  end if
+

--- a/other/ntlm-authentication-discovery.bcheck
+++ b/other/ntlm-authentication-discovery.bcheck
@@ -1,0 +1,20 @@
+metadata:
+  language: v1-beta
+  name: "NTLM Authentication Detection"
+  description: "Detects NTLM authentication on non-standard directories."
+  author: "@puzzlepeaches"
+  tags: "login", "ntlm", "authentication"
+
+given request then
+    send request called check:
+        method: "GET"
+        appending headers:
+            "Authorization": "NTLM TlRMTVNTUAABAAAAB4IIAAAAAAAgAAAAAAAAACAAAAA="
+
+    if {check.response.status_code} is "401" and {check.response.headers} matches "WWW-Authenticate: NTLM" then 
+            report issue:
+                severity: low 
+                confidence: firm
+                detail: "NTLM authentication is enabled on a non-standard directory."
+                remediation: "Disable NTLM authentication in favor of modern authentication protocols."
+    end if


### PR DESCRIPTION
The following bchecks were added in this pull request:

* NTLM endpoint detection
* Git config detection
* Ruby on Rails storage.yml detection
* NPM debug log detection
* IIS web.config file detection
* PHP info file detection

These checks are unique in looking for file disclosure in that they don't just look at the site's root page but all directories discovered during a crawl. For example, if the following URL is discovered:

* https://site.acme.com/login

The checks look for git config files trailing the login directory like so:

* https://site.acme.com/login/.git/config


