### PR TITLE
added NetScaler and citrixADC icon detection

### DIFF
--- a/other/Netscaler_CitrixADC_hash_icon_detection.bcheck
+++ b/other/Netscaler_CitrixADC_hash_icon_detection.bcheck
@@ -6,9 +6,9 @@ metadata:
 		author: "Randsec"
 
 given response then
-		if "/vpn/images/AccessGateway.ico" in {latest.response.body} or "receiver/images/common/icon_vpn.ico" in {latest.response.body} then
-				report issue:
-					severity: info
-					confidence: firm
-					detail: "Possible Netscaler / Citrix ADC detected"
-		end if
+    if "/vpn/images/AccessGateway.ico" in {latest.response.body} or "receiver/images/common/icon_vpn.ico" in {latest.response.body} then
+        report issue:
+            severity: info
+            confidence: firm
+            detail: "Possible Netscaler / Citrix ADC detected"
+    end if

--- a/other/Netscaler_CitrixADC_hash_icon_detection.bcheck
+++ b/other/Netscaler_CitrixADC_hash_icon_detection.bcheck
@@ -1,0 +1,14 @@
+metadata:
+    language: v1-beta
+    name: "Netscaler/CitrixADC Icon Hash"
+    description: "Detects the hash of Netscaler and Citrix ADC"
+    tags: "passive"
+		author: "Randsec"
+
+given response then
+		if "/vpn/images/AccessGateway.ico" in {latest.response.body} or "receiver/images/common/icon_vpn.ico" in {latest.response.body} then
+				report issue:
+					severity: info
+					confidence: firm
+					detail: "Possible Netscaler / Citrix ADC detected"
+		end if

--- a/other/Netscaler_CitrixADC_hash_icon_detection.bcheck
+++ b/other/Netscaler_CitrixADC_hash_icon_detection.bcheck
@@ -3,7 +3,7 @@ metadata:
     name: "Netscaler/CitrixADC Icon Hash"
     description: "Detects the hash of Netscaler and Citrix ADC"
     tags: "passive"
-		author: "Randsec"
+    author: "Randsec"
 
 given response then
     if "/vpn/images/AccessGateway.ico" in {latest.response.body} or "receiver/images/common/icon_vpn.ico" in {latest.response.body} then


### PR DESCRIPTION
This bcheck detects the netscaler and citrix adc icon on requests, which may be affected by CVE-2023-3519.