### PR TITLE
Update CVE-2023-24488 - Avoid false positives

### DIFF
--- a/vulnerabilities-CVEd/CVE-2023-24488 - Citrix Gateway Open Redirect and XSS.bcheck
+++ b/vulnerabilities-CVEd/CVE-2023-24488 - Citrix Gateway Open Redirect and XSS.bcheck
@@ -14,7 +14,7 @@ given host then
         method: "GET"
         path: {potential_path}
 
-    if "document.cookie" in {check.response.body} then
+    if "<script>alert(document.cookie)</script>" in {check.response.body} then
         report issue:
             severity: medium
             confidence: certain


### PR DESCRIPTION
This will avoid false positives due to the fact that some 404 status pages returns the introduced parameter encoding the "<" and ">" characters, but not the ".", so "document.cookie" appears but the rest of the payload is as introduced, "%3Cscript%3Ealert(document.cookie)%3C/script%3e". The payload should match fully in a positive case.