### PR TITLE
Adding PathSuffix-Bypass-4ProxyOrWAF

### DIFF
--- a/other/bypass/PathSuffix_WAF_Proxy.bcheck
+++ b/other/bypass/PathSuffix_WAF_Proxy.bcheck
@@ -1,7 +1,7 @@
 metadata:
     language: v2-beta
     name: "PathSuffix-Bypass-4ProxyOrWAF"
-    description: "Accessing paths blocked by proxies or WAFs by adding meaningful suffixes."
+    description: "Accessing paths blocked by proxies or WAFs by adding special suffixes."
     author: "Soroush Dalili"
     tags: "bypass", "path", "waf", "proxy", "access"
 

--- a/other/bypass/PathSuffix_WAF_Proxy.bcheck
+++ b/other/bypass/PathSuffix_WAF_Proxy.bcheck
@@ -1,0 +1,48 @@
+metadata:
+    language: v2-beta
+    name: "PathSuffix-Bypass-4ProxyOrWAF"
+    description: "Accessing paths blocked by proxies or WAFs by adding meaningful suffixes."
+    author: "Soroush Dalili"
+    tags: "bypass", "path", "waf", "proxy", "access"
+
+# Also see https://book.hacktricks.xyz/pentesting-web/proxy-waf-protections-bypass
+
+run for each:
+    suffix =
+        "/",
+        ".",
+        ";",
+        "%00", #null
+        "%09", #tab
+        "%0a", #new line
+        "%20", #space
+        "%3b", #semi-colon
+        "%3f", #question-mark
+        `{base64_decode("oA==")}`, #\xA0
+        `{base64_decode("hQ==")}`, #\x85
+        "/style.css",
+        ";style.css",
+        "%3fstyle.css",
+        "%00style.css"
+
+given path then
+    if not ({base.response.status_code} is "200") then
+        send request called check:
+            appending path: {suffix}
+
+        if not({check.response.status_code} is {base.response.status_code}) then
+            if {base.response.status_code} matches "40(1|3)" and {check.response.status_code} is "200" then
+                report issue and continue:
+                    severity: high
+                    confidence: firm
+                    detail: `Path access control bypass at {check.request.url}`
+                    remediation: "Ensure that the requested endpoint is only accessible to authorized users."
+            else if {check.response.status_code} matches "[12]0[0-9]" or {check.response.status_code} is "500" then
+                report issue and continue:
+                    severity: high
+                    confidence: tentative
+                    detail: `Potential path access control bypass at {check.request.url}`
+                    remediation: "Manual review is required to confirm this issue. If there is a bypass, ensure that the requested endpoint is only accessible to authorized users."
+            end if
+        end if
+    end if


### PR DESCRIPTION
Adding PathSuffix-Bypass-4ProxyOrWAF.

Accessing paths blocked by proxies or WAFs by adding special suffixes.

Things like `%A0` for Nginx (https://book.hacktricks.xyz/pentesting-web/proxy-waf-protections-bypass) will not work with HTTP/2 -> I was not sure if this can be enforced by BChecks but it would be great to have this option.