### PR TITLE
Propose a bcheck to detect stack traces.

### DIFF
--- a/other/stackTrace.bcheck
+++ b/other/stackTrace.bcheck
@@ -1,0 +1,53 @@
+metadata:
+    language: v1-beta
+    name: "Stack trace was detected"
+    description: "Detect when a response contains a stack trace."
+    author: "Dominique Righetto"
+    tags: "passive","informative"
+
+define:
+    common_detail = "The response contains a stack trace that discloses information about the server-side technology used: "
+    common_remediation = "Add an error handler to ensure any errors that may occur are caught, then return a generic message."
+
+given response then
+    # Source: https://github.com/righettod/burp-piper-custom-scripts/blob/main/detect-response-with-errors-disclosure.py
+    # Java
+    if {latest.response.body} matches "(java\.[\w]+\.[\w]+)" then
+        report issue:
+            severity: info
+            confidence: firm
+            detail: `{common_detail} Java.`
+            remediation: `{common_remediation}`
+    end if
+    # .Net
+    if {latest.response.body} matches "(\w+Exception:\s['\"\w\d\s]+)" then
+        report issue:
+            severity: info
+            confidence: firm
+            detail: `{common_detail} .NET.`
+            remediation: `{common_remediation}`
+    end if
+    # NodeJS
+    if {latest.response.body} matches "(at\stryModuleLoad\s)" then
+        report issue:
+            severity: info
+            confidence: firm
+            detail: `{common_detail} NodeJS.`
+            remediation: `{common_remediation}`
+    end if
+    # PHP
+    if {latest.response.body} matches "(\.php\son\sline\s\d+)" then
+        report issue:
+            severity: info
+            confidence: firm
+            detail: `{common_detail} PHP.`
+            remediation: `{common_remediation}`
+    end if
+    # RUBY
+    if {latest.response.body} matches "(\.rb:\d+:in)" then
+        report issue:
+            severity: info
+            confidence: firm
+            detail: `{common_detail} Ruby.`
+            remediation: `{common_remediation}`
+    end if


### PR DESCRIPTION
### Description

Hi,

This PR propose a **bcheck** to perform the following operation: 

*Detect when a response contains a stack trace, supporting several technologies.*

### BCheck Contributions

* [x] BCheck compiles and executes as expected: [Proof](https://github.com/righettod/bchecks-library/actions/runs/8124312997/job/22205643863)
  
![image](https://github.com/righettod/BChecks/assets/1573775/fff32dea-a607-416a-a742-0c800b6dda01)

* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives
