### PR TITLE
Update CVE-2011-3192-Apache DoS.bcheck

### DIFF
--- a/vulnerabilities-CVEd/CVE-2011-3192-Apache DoS.bcheck
+++ b/vulnerabilities-CVEd/CVE-2011-3192-Apache DoS.bcheck
@@ -9,8 +9,9 @@ metadata:
     #the "stronger" payload is not enabled by default, as payloads are tried for every single 200 response for the unique path. Therefore it could perform unintentional Denial of Service against the server.
     #in case you use the 2nd payload it is highly recommended to test a single request at the time
     define:
-        DoS_payload = "bytes=0-"
+        DoS_payload = "bytes=0-,0-"
     #    DoS_payload = "bytes=0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-"
+        response_payload = "Content-range: bytes"
 
 given path then
     send request called check:
@@ -22,7 +23,8 @@ given path then
                 headers: "Range": {DoS_payload}
                 headers: "Request-Range": {DoS_payload}
     
-        if {DoS.response.status_code} is "206" then
+        if {DoS.response.status_code} is "206" and
+            ({response_payload} in {DoS.response.body}) then
             report issue:
                 severity: high
                 confidence: firm


### PR DESCRIPTION
added check in response body to cut down on false positives

### BCheck Contributions

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives
