### PR TITLE
Propose check to detect misconfiguration for CORS credentials requested.

### DIFF
--- a/other/corsCredentialedRequestsMisconfiguration.bcheck
+++ b/other/corsCredentialedRequestsMisconfiguration.bcheck
@@ -1,0 +1,18 @@
+metadata:
+    language: v2-beta
+    name: "Invalid CORS configuration for credentialed requests detected"
+    description: "Checks for a broken CORS configuration case: Credentialed requests and wildcards."
+    author: "Dominique Righetto"
+    tags: "passive", "informative"
+
+# The server must not specify the "*" wildcard for the Access-Control-Allow-Origin response-header value, but must instead specify an explicit origin 
+# Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#requests_with_credentials
+given response then
+    if {latest.response.headers} matches "(?i)Access-Control-Allow-Origin:\s+\*" and
+        {latest.response.headers} matches "(?i)Access-Control-Allow-Credentials:\s+true" then
+        report issue:
+            severity: info
+            confidence: firm
+            detail: "Credentialed CORS requests cannot used wildcards origins."
+            remediation: "Specify an explicit allow origin. Refer to the Mozilla CORS documentation for technical details: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#requests_with_credentials"
+    end if


### PR DESCRIPTION
### Description

This PR propose a bcheck to detect invalid CORS configuration for credentialed requests.

Indeed, the server must not specify the `*` wildcard for the `Access-Control-Allow-Origin` response-header value, but must instead specify an explicit origin.

Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#requests_with_credentials

File was validated with the latest version of the checker:

![image](https://github.com/PortSwigger/BChecks/assets/1573775/d2ac6553-c726-4ae7-8003-90ac966433b6)

### BCheck Contributions

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives

Thanks in advance 😃 
