### PR TITLE
Check capability to override the HTTP method.

### DIFF
--- a/other/httpMethodOverrideCapability.bcheck
+++ b/other/httpMethodOverrideCapability.bcheck
@@ -1,0 +1,36 @@
+metadata:
+  language: v2-beta
+  name: "HTTP method override capability detected"
+  description: "Check for the support for a request parameter or a request header allowing to override the HTTP method."
+  author: "Dominique Righetto"
+  tags: "active"
+
+define:
+  test_method = "OPTIONS"
+
+# To prevent causing any trouble on the target app then only apply the check on GET requests
+# Sources:
+# https://github.com/PortSwigger/param-miner/blob/master/resources/headers
+# https://github.com/PortSwigger/param-miner/blob/master/resources/params
+# https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods
+# https://www.sidechannel.blog/en/http-method-override-what-it-is-and-how-a-pentester-can-use-it/
+given path then
+    if {base.request.method} is "GET" then
+        send request called checkOverrideSupport:
+            appending headers:
+                "x-method-override": `{test_method}`,
+                "x-http-method-override": `{test_method}`,
+                "x-http-method": `{test_method}`,
+                "request-method": `{test_method}`
+            appending queries:
+                `method={test_method}`,
+                `_method={test_method}`
+
+         if {checkOverrideSupport.response.headers} matches "(?i)allow:\s+[A-Z,]+" then
+            report issue:
+                severity: info
+                confidence: firm
+                detail: "Endpoints support a hidden parameter/header, allowing to override the HTTP method effectively used to handle the HTTP requests."
+                remediation: "Remove the support for the hidden request parameters/headers."
+        end if
+    end if


### PR DESCRIPTION
### Description

Hi,

This PR propose a bcheck to check for the support for a request parameter or a request header allowing to override the HTTP method.

### BCheck Contributions

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives

### Tests

![image](https://github.com/PortSwigger/BChecks/assets/1573775/955ef171-778b-4cb4-ba1a-4beef19dd15b)

![image](https://github.com/PortSwigger/BChecks/assets/1573775/bdb2d8dd-deb7-4388-82fe-eef240801172)

