### PR TITLE
Fix typo in splitting attack bcheck

### DIFF
--- a/other/email/email-splitting-attack.bcheck
+++ b/other/email/email-splitting-attack.bcheck
@@ -20,7 +20,7 @@ define:
 
 run for each:
     payload =
-        "=?iso-8859-1?q?{payload]=40{url}=3e=00?=foo@{target_host}",
+        "=?iso-8859-1?q?{payload}=40{url}=3e=00?=foo@{target_host}",
         "=?iso-8859-1?q?{payload}=40{url}=3e=01?=foo@{target_host}",
         "=?iso-8859-1?q?{payload}=40{url}=3e=02?=foo@{target_host}",
         "=?iso-8859-1?q?{payload}=40{url}=3e=03?=foo@{target_host}",


### PR DESCRIPTION
### BCheck Contributions

Fix typo in email word list

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives
