### PR TITLE
Update CVE-2011-3192-Apache DoS.bcheck

### DIFF
--- a/vulnerabilities-CVEd/CVE-2011-3192-Apache DoS.bcheck
+++ b/vulnerabilities-CVEd/CVE-2011-3192-Apache DoS.bcheck
@@ -11,7 +11,7 @@ metadata:
     define:
         DoS_payload = "bytes=0-,0-"
     #    DoS_payload = "bytes=0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-,0-"
-        response_payload = "Content-range: bytes"
+        response_payload = "content-range: bytes"
 
 given path then
     send request called check:
@@ -22,9 +22,10 @@ given path then
             method: "GET"
                 headers: "Range": {DoS_payload}
                 headers: "Request-Range": {DoS_payload}
+                headers: "Content-Range": {DoS_payload}
     
         if {DoS.response.status_code} is "206" and
-            ({response_payload} in {DoS.response.body}) then
+            ({response_payload} in {to_lower(DoS.response.body)}) then
             report issue:
                 severity: high
                 confidence: firm

--- a/vulnerabilities-CVEd/CVE-2018-15133-Laravel RCE.bcheck
+++ b/vulnerabilities-CVEd/CVE-2018-15133-Laravel RCE.bcheck
@@ -1,0 +1,35 @@
+metadata:
+    language: v2-beta
+    name: "[CVE-2018-15133] PHP Laravel Framework token Unserialize Remote Command Execution"
+    description: "Laravel RCE"
+    #there are many writeups and PoC of CVE-2018-15133. I didn't have anything with the original research, just writing this BCheck.
+    author: "Andrej Šimko @ Accenture"
+    tags: "CVE-2018-15133", "Laravel", "RCE", "Remote Code Execution"
+
+# HTTP/2 needs to be disabled in Settings>Network>HTTP>HTTP/2. This is because the HTTP header in question (X-XSRF-TOKEN) needs to be all upper-case, where HTTP/2 does not nativly support different case sensitivity for header names. See "Header capitalization" on https://portswigger.net/burp/documentation/desktop/http2/http2-basics-for-burp-users.
+define:
+    payload = "xxxx"
+    response_payload1 = "laravel"
+    response_payload2 = "Encrypter.php"
+
+given host then
+    send request called try:
+        #as of BCheck v2-beta it is not possible to create an HTTP/1.1 request, even in this way when HTTP/2 is enabled.
+        `POST / HTTP/1.1
+Host: {base.request.url.host}
+Referer: {base.request.url.host}
+Content-Type: application/x-www-form-urlencoded
+Origin: {base.request.url.host}
+X-XSRF-TOKEN: {payload}
+Content-Length: 0
+
+`
+
+    if ({response_payload1} in {try.response.body}) and
+    ({response_payload2} in {try.response.body}) then
+        report issue:
+            severity: high
+            confidence: firm
+            detail: "The PHP Laravel Framework for versions 5.5.40, 5.6.x <= 5.6.29 is vulnerable to RCE through deserialization. To exploit further you would need to obtain APP_KEY."
+            remediation: "Update Laravel to the latest version."
+    end if


### PR DESCRIPTION
added a new header Content-Range; improved rules for detection to compare in a case-insensitive way.

### BCheck Contributions

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives
