### PR TITLE
Create 000~ROOT~000-exposed.bcheck

### DIFF
--- a/other/files/000~ROOT~000-exposed.bcheck
+++ b/other/files/000~ROOT~000-exposed.bcheck
@@ -1,0 +1,22 @@
+metadata:
+    language: v1-beta
+    name: "Filesystem exposure via /home/000~ROOT~000/"
+    description: "Tests for exposed 000~ROOT~000 in current path and at the root directory of site"
+    author: "r3nt0n"
+    tags: "exposure", "path traversal"
+
+run for each:
+  payloads_array = 
+    "/home/000~ROOT~000/",
+    `{base.request.url.path}/home/000~ROOT~000/`
+
+given request then
+    send request:
+        replacing path: `{payloads_array}`
+
+    if "Index of" in {latest.response} then
+            report issue:
+                severity: high
+                confidence: firm
+                detail: "Potential exposure of entire filesystem via \"/home/000~ROOT~000\" path"
+    end if

--- a/other/files/000~ROOT~000-exposed.bcheck
+++ b/other/files/000~ROOT~000-exposed.bcheck
@@ -1,17 +1,18 @@
 metadata:
-    language: v1-beta
+    language: v2-beta
     name: "Filesystem exposure via /home/000~ROOT~000/"
     description: "Tests for exposed 000~ROOT~000 in current path and at the root directory of site"
     author: "r3nt0n"
-    tags: "exposure", "path traversal"
+    tags: "active", "exposure", "path traversal"
 
 run for each:
   payloads_array = 
     "/home/000~ROOT~000/",
-    `{base.request.url.path}/home/000~ROOT~000/`
+    `{regex_replace(base.request.url.path, "/$", "")}/home/000~ROOT~000/`
 
-given request then
+given path then
     send request:
+        replacing method: "GET"
         replacing path: `{payloads_array}`
 
     if "Index of" in {latest.response} then


### PR DESCRIPTION
### BCheck Contributions

This Bcheck attempts to detect the exposure of `000~ROOT~000` file, which can be leveraged like a path traversal to access the entire filesystem.

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives
