### PR TITLE
Added Ignore Image Files Option to UUID BCheck

### DIFF
--- a/other/uuid-detected-guid-versions.bcheck
+++ b/other/uuid-detected-guid-versions.bcheck
@@ -2,15 +2,24 @@ metadata:
     language: v1-beta
     name: "UUID detected"
     description: "This bcheck template passively identifies and reports the use of various UUID versions within application."
-    author: "vavkamil"
+    author: "vavkamil, alp1n3.eth"
     tags: "passive", "guid", "uuid"
 
 define:
     # Modify config based on the application you are testing :)
-    config_check_request  = "False" # It will return a lot of noise, like cookies
-    config_check_response = "True"  # It will return a lot of noise, like response headers
-    config_request_url    = "False" # It will identify GET/POST/PUT/PATCH requests from Frontend with no UUID in response
-    config_request_body   = "False" # It will identify POST/PUT/PATCH requests from Frontend with no UUID in response
+    # Request config
+    config_check_request = "False"
+    # It will return a lot of noise, like cookies
+    config_request_url = "False"
+    # It will identify GET/POST/PUT/PATCH requests from Frontend with no UUID in response
+    config_request_body = "False"
+    # It will identify POST/PUT/PATCH requests from Frontend with no UUID in response
+    # Response config
+    config_check_response = "True"
+    # It will return a lot of noise, like response headers
+    config_ignore_response_images = "True"
+    # It will ignore responses that contain popular image headers in their Content-Type header
+    # Current files ignored: gif, png, jpeg, svg+xml
     ####################################################################################################
     references = "References
 - https://www.intruder.io/research/in-guid-we-trust
@@ -63,38 +72,79 @@ An attacker might be able to generate UUID using predictable data."
 given response then
     # Check UUID anywhere in response
     if {config_check_response} matches "True" then
-        # UUID v1 - RFC 4122 variant
-        # Example: 0f9a9c50-79b9-11ee-b962-0242ac120002
-        if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
-            report issue:
-                severity: high
-                confidence: firm
-                detail: `{issueDetail_uuid_v1}`
-                remediation: `{issueRemediation}`
-        # UUID v3 - RFC 4122 variant
-        # Example: 3d813cbb-47fb-32ba-91df-831e1593ac29
-        else if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[3][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
-            report issue:
-                severity: low
-                confidence: firm
-                detail: `{issueDetail_uuid_v3}`
-                remediation: `{issueRemediation}`
-        # UUID v4 - RFC 4122 variant
-        # Example: 9f1e379d-e839-4d3a-9c2a-1d4dde67f75c
-        else if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[4][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
-            report issue:
-                severity: info
-                confidence: firm
-                detail: `{issueDetail_uuid_v4}`
-                remediation: `{issueRemediation_ok}`
-        # UUID v5 - RFC 4122 variant
-        # Example: 74738ff5-5367-5958-9aee-98fffdcd1876
-        else if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
-            report issue:
-                severity: low
-                confidence: firm
-                detail: `{issueDetail_uuid_v5}`
-                remediation: `{issueRemediation}`
+        if {config_ignore_response_images} matches "True" then
+            if not("image/gif" in {base.response.headers}) or
+            not("image/png" in {base.response.headers}) or
+            not("image/jpeg" in {base.response.headers}) or
+            not("image/svg+xml" in {base.response.headers}) then
+                # UUID v1 - RFC 4122 variant
+                # Example: 0f9a9c50-79b9-11ee-b962-0242ac120002
+                if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
+                    report issue:
+                        severity: high
+                        confidence: firm
+                        detail: `{issueDetail_uuid_v1}`
+                        remediation: `{issueRemediation}`
+                    # UUID v3 - RFC 4122 variant
+                    # Example: 3d813cbb-47fb-32ba-91df-831e1593ac29
+                else if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[3][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
+                    report issue:
+                        severity: low
+                        confidence: firm
+                        detail: `{issueDetail_uuid_v3}`
+                        remediation: `{issueRemediation}`
+                    # UUID v4 - RFC 4122 variant
+                    # Example: 9f1e379d-e839-4d3a-9c2a-1d4dde67f75c
+                else if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[4][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
+                    report issue:
+                        severity: info
+                        confidence: firm
+                        detail: `{issueDetail_uuid_v4}`
+                        remediation: `{issueRemediation_ok}`
+                    # UUID v5 - RFC 4122 variant
+                    # Example: 74738ff5-5367-5958-9aee-98fffdcd1876
+                else if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
+                    report issue:
+                        severity: low
+                        confidence: firm
+                        detail: `{issueDetail_uuid_v5}`
+                        remediation: `{issueRemediation}`
+                end if
+            end if
+        else then
+            # UUID v1 - RFC 4122 variant
+            # Example: 0f9a9c50-79b9-11ee-b962-0242ac120002
+            if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
+                report issue:
+                    severity: high
+                    confidence: firm
+                    detail: `{issueDetail_uuid_v1}`
+                    remediation: `{issueRemediation}`
+                # UUID v3 - RFC 4122 variant
+                # Example: 3d813cbb-47fb-32ba-91df-831e1593ac29
+            else if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[3][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
+                report issue:
+                    severity: low
+                    confidence: firm
+                    detail: `{issueDetail_uuid_v3}`
+                    remediation: `{issueRemediation}`
+                # UUID v4 - RFC 4122 variant
+                # Example: 9f1e379d-e839-4d3a-9c2a-1d4dde67f75c
+            else if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[4][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
+                report issue:
+                    severity: info
+                    confidence: firm
+                    detail: `{issueDetail_uuid_v4}`
+                    remediation: `{issueRemediation_ok}`
+                # UUID v5 - RFC 4122 variant
+                # Example: 74738ff5-5367-5958-9aee-98fffdcd1876
+            else if {base.response} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
+                report issue:
+                    severity: low
+                    confidence: firm
+                    detail: `{issueDetail_uuid_v5}`
+                    remediation: `{issueRemediation}`
+            end if
         end if
     end if
 
@@ -108,24 +158,24 @@ given response then
                 confidence: firm
                 detail: `{issueDetail_uuid_v1}`
                 remediation: `{issueRemediation}`
-        # UUID v3 - RFC 4122 variant
-        # Example: 3d813cbb-47fb-32ba-91df-831e1593ac29
+            # UUID v3 - RFC 4122 variant
+            # Example: 3d813cbb-47fb-32ba-91df-831e1593ac29
         else if {base.request} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[3][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
             report issue:
                 severity: low
                 confidence: firm
                 detail: `{issueDetail_uuid_v3}`
                 remediation: `{issueRemediation}`
-        # UUID v4 - RFC 4122 variant
-        # Example: 9f1e379d-e839-4d3a-9c2a-1d4dde67f75c
+            # UUID v4 - RFC 4122 variant
+            # Example: 9f1e379d-e839-4d3a-9c2a-1d4dde67f75c
         else if {base.request} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[4][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
             report issue:
                 severity: info
                 confidence: firm
                 detail: `{issueDetail_uuid_v4}`
                 remediation: `{issueRemediation_ok}`
-        # UUID v5 - RFC 4122 variant
-        # Example: 74738ff5-5367-5958-9aee-98fffdcd1876
+            # UUID v5 - RFC 4122 variant
+            # Example: 74738ff5-5367-5958-9aee-98fffdcd1876
         else if {base.request} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
             report issue:
                 severity: low
@@ -145,24 +195,24 @@ given response then
                 confidence: firm
                 detail: `{issueDetail_uuid_v1}`
                 remediation: `{issueRemediation}`
-        # UUID v3 - RFC 4122 variant
-        # Example: 3d813cbb-47fb-32ba-91df-831e1593ac29
+            # UUID v3 - RFC 4122 variant
+            # Example: 3d813cbb-47fb-32ba-91df-831e1593ac29
         else if {base.request.url} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[3][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
             report issue:
                 severity: low
                 confidence: firm
                 detail: `{issueDetail_uuid_v3}`
                 remediation: `{issueRemediation}`
-        # UUID v4 - RFC 4122 variant
-        # Example: 9f1e379d-e839-4d3a-9c2a-1d4dde67f75c
+            # UUID v4 - RFC 4122 variant
+            # Example: 9f1e379d-e839-4d3a-9c2a-1d4dde67f75c
         else if {base.request.url} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[4][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
             report issue:
                 severity: info
                 confidence: firm
                 detail: `{issueDetail_uuid_v4}`
                 remediation: `{issueRemediation_ok}`
-        # UUID v5 - RFC 4122 variant
-        # Example: 74738ff5-5367-5958-9aee-98fffdcd1876
+            # UUID v5 - RFC 4122 variant
+            # Example: 74738ff5-5367-5958-9aee-98fffdcd1876
         else if {base.request.url} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
             report issue:
                 severity: low
@@ -182,24 +232,24 @@ given response then
                 confidence: firm
                 detail: `{issueDetail_uuid_v1}`
                 remediation: `{issueRemediation}`
-        # UUID v3 - RFC 4122 variant
-        # Example: 3d813cbb-47fb-32ba-91df-831e1593ac29
+            # UUID v3 - RFC 4122 variant
+            # Example: 3d813cbb-47fb-32ba-91df-831e1593ac29
         else if {base.request.body} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[3][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
             report issue:
                 severity: low
                 confidence: firm
                 detail: `{issueDetail_uuid_v3}`
                 remediation: `{issueRemediation}`
-        # UUID v4 - RFC 4122 variant
-        # Example: 9f1e379d-e839-4d3a-9c2a-1d4dde67f75c
+            # UUID v4 - RFC 4122 variant
+            # Example: 9f1e379d-e839-4d3a-9c2a-1d4dde67f75c
         else if {base.request.body} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[4][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
             report issue:
                 severity: info
                 confidence: firm
                 detail: `{issueDetail_uuid_v4}`
                 remediation: `{issueRemediation_ok}`
-        # UUID v5 - RFC 4122 variant
-        # Example: 74738ff5-5367-5958-9aee-98fffdcd1876
+            # UUID v5 - RFC 4122 variant
+            # Example: 74738ff5-5367-5958-9aee-98fffdcd1876
         else if {base.request.body} matches "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}" then
             report issue:
                 severity: low


### PR DESCRIPTION
This is a fix in reference to the following issue: #193 

I've added the configuration option to ignore the content-types related to the following image files: gif, png, jpeg, svg+xml. More can be added, in original issue request they reference it hitting on .exe files, but I could only find files with valid FP hits for the above extensions and not an .exe. If needed, I can throw that check in there as well, but I wanted to keep this as "realistic" as possible and only added checks for FP hits that I observed and could therefore test against.

### BCheck Contributions

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives
