### PR TITLE
Added JetBrain Files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .vscode
+.idea


### PR DESCRIPTION
I've added this in order to ignore the default files generated by JetBrain's IDEs, such as GoLand. Normally I'd just ignore it but I've been split between several VMs & computers recently and it keeps asking me on each (haha). In the interest of keeping commits clean I am submitting this separately instead of along with a BCheck. 

### BCheck Contributions - Not Applicable, no BChecks were altered/added.
