### PR TITLE
Added OOB SSRF Checks for HTTP + DNS

### DIFF
--- a/vulnerability-classes/injection/ExtendedSSRFInjection.bcheck
+++ b/vulnerability-classes/injection/ExtendedSSRFInjection.bcheck
@@ -1,0 +1,31 @@
+metadata:
+    language: v2-beta
+    name: "Extended Out-of-Band SSRF Injections"
+    description: "Inserts a Collaborator address into each parameter to detect SSRF with different schemes and paths through HTTP or DNS interactions."
+    author: "alp1n3.eth"
+    tags: "active", "injection", "ssrf", "server-side request forgery", "scan", "collaborator"
+
+run for each:
+    ssrfaddress= `{generate_collaborator_address()}/xyz`, `http://{generate_collaborator_address()}/xyz`, `https://{generate_collaborator_address()}/xyz`, `www.{generate_collaborator_address()}/xyz`
+
+
+given insertion point then
+    send payload:
+        replacing: {ssrfaddress}
+
+    if http interactions then
+        report issue and continue:
+            severity: high
+            confidence: firm
+            detail: "HTTP OOB SSRF Discovery by BCheck: Explore the Request Tab to Observe the Payload and Attempt to Self-Capture."
+            remediation: "Implement SSRF remediation measures to mitigate the vulnerability."
+    end if
+
+
+    if dns interactions  then
+        report issue:
+            severity: medium
+            confidence: tentative
+            detail: "DNS OOB SSRF Discovery by BCheck: Explore the Request Tab to Observe the Payload and Attempt to Self-Capture. Ensure the interaction is from the target URL and not a CDN/proxy/etc."
+            remediation: "Implement SSRF remediation measures to mitigate the vulnerability."
+    end if


### PR DESCRIPTION
Contains checks that may detect certain scenarios where valid URLs might need a different path or scheme to achieve OOB SSRF.

### BCheck Contributions

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives
