### PR TITLE
Create Firebase-Detect.bcheck

### DIFF
--- a/other/technologies/Firebase-Detect.bcheck
+++ b/other/technologies/Firebase-Detect.bcheck
@@ -1,0 +1,14 @@
+metadata:
+    language: v2-beta
+    name: "Firebase Information Found"
+    description: "Detect potentially exposed Firebase instances"
+    tags: "passive, firebase"
+
+given response then
+    if {latest.response.body} matches ".*\.firebaseapp\.com.*" then
+        report issue:
+            severity: low
+            confidence: firm
+            detail: "Potentially exposed Firebase instance detected in response."
+            remediation: "Review the Firebase instance to ensure it does not allow unautohrized users to read/write to database."
+    end if


### PR DESCRIPTION
Firebase Technology Detection Script

### BCheck Contributions

* [✅] BCheck compiles and executes as expected
* [✅] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [✅] Only .bcheck files have been added or modified
* [✅] BCheck is in the appropriate folder
* [✅] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [❗] BCheck attempts to minimize false positives

It is prone to false positive, for example: if its a forum or guestbook or something like that and people talk about 'firebaseapp.com' then this will most likely trigger as it would detect it in the response.

I suppose this could be improved to detect firebase keys, instances etc.. so while this works. It can defiantly be improved.