### PR TITLE
Added bcheck for Next.js Bypass CVE-2025-29927

### DIFF
--- a/vulnerabilities-CVEd/CVE-2025-29927-Next-js-middleware-bypass.bcheck
+++ b/vulnerabilities-CVEd/CVE-2025-29927-Next-js-middleware-bypass.bcheck
@@ -1,0 +1,19 @@
+metadata:
+    language: v2-beta
+    name: "CVE-2025-29927 Next.js Middleware Bypass"
+    description: "Next.js Detected, possible vulnerability"
+    author: "Paul Schmelzel"
+    tags: "CVE-2025-29927","Next.js","Nextjs","Bypass"
+
+given request then
+    send request:
+        headers:
+            "x-nextjs-data": "1"
+
+    if {latest.response.headers} matches "x-nextjs-rewrite:" then
+        report issue:
+            severity: medium
+            confidence: firm
+            detail: "The site is using NextJS and may be vulnerble to a bypass as described in CVE-2025-29927. See https://slcyber.io/assetnote-security-research-center/doing-the-due-diligence-analysing-the-next-js-middleware-bypass-cve-2025-29927/ for further exploit details."
+            remediation: "Do not accept headers from users such as x-nextjs-data or x-middleware-subrequest."
+    end if


### PR DESCRIPTION
A bcheck for the recent Next.js Bypass identified as CVE-2025-29927. Used https://slcyber.io/assetnote-security-research-center/doing-the-due-diligence-analysing-the-next-js-middleware-bypass-cve-2025-29927/ for creating this. 

This is my first contribution so all feedback is welcomed. 

### BCheck Contributions

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives
