### PR TITLE
Added bcheck to detect JWTs that utilize HMAC algorithms

### DIFF
--- a/other/tokens/jwt-hmac-alg-detected.bcheck
+++ b/other/tokens/jwt-hmac-alg-detected.bcheck
@@ -6,15 +6,11 @@ metadata:
     tags: "passive", "jwt", "hmac", "hashcat"
 
 given response then
-    if {latest.response} matches "(eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9|eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9|eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9|eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9|eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9|eyJhbGciOiJIUzI1NiJ9|eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9|eyJhbGciOiJIUzM4NCJ9|eyJhbGciOiJIUzUxMiJ9)" then
+    if {latest.response} matches "(eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9|eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9|eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9|eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9|eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9|eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9|eyJhbGciOiJIUzI1NiJ9|eyJhbGciOiJIUzM4NCJ9|eyJhbGciOiJIUzUxMiJ9)" then
         report issue:
             severity: info
             confidence: certain
             detail: "JWT using HMAC (HS256 / HS384 / HS512) detected in response. You can submit this JWT to hashcat for cracking using `hashcat -a 0 -m 16500 <JWT> <wordfile>`"
             remediation: "Avoid using HMAC (symmetric) signing algorithms for JWTs in security-sensitive applications."
-    end if
-              extra:
-                    hashcat_format: "JWT Hash for cracking: $jwt"
-        end if
     end if
 

--- a/other/tokens/jwt-hmac-alg-detected.bcheck
+++ b/other/tokens/jwt-hmac-alg-detected.bcheck
@@ -1,0 +1,20 @@
+metadata:
+    language: v2-beta
+    name: "HMAC-Signed JWT Identified"
+    description: "Detects JWTs using HMAC signing in responses"
+    author: "Paul Schmelzel"
+    tags: "passive", "jwt", "hmac", "hashcat"
+
+given response then
+    if {latest.response} matches "(eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9|eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9|eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9|eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzM4NCJ9|eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9|eyJhbGciOiJIUzI1NiJ9|eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9|eyJhbGciOiJIUzM4NCJ9|eyJhbGciOiJIUzUxMiJ9)" then
+        report issue:
+            severity: info
+            confidence: certain
+            detail: "JWT using HMAC (HS256 / HS384 / HS512) detected in response. You can submit this JWT to hashcat for cracking using `hashcat -a 0 -m 16500 <JWT> <wordfile>`"
+            remediation: "Avoid using HMAC (symmetric) signing algorithms for JWTs in security-sensitive applications."
+    end if
+              extra:
+                    hashcat_format: "JWT Hash for cracking: $jwt"
+        end if
+    end if
+


### PR DESCRIPTION
This is in response to a request on the Burp discord server for a bcheck that alerts on a JWT using HMAC.

This bcheck looks for JWTs using HMAC in the following formats:
```
{"alg":"HS256","typ":"JWT"}
{"typ":"JWT","alg":"HS256"}
{"alg":"HS384","typ":"JWT"}
{"typ":"JWT","alg":"HS384"}
{"alg":"HS512","typ":"JWT"}
{"typ":"JWT","alg":"HS512"}
{"alg":"HS256"}
{"alg":"HS384"}
{"alg":"HS512"}
```

I tried to extract JWTs and base64 decode them to retrieve the algorithm, but I did not find this functionality in bchecks. If that exists, please point me to further documentation and I can try to rewrite this to be more accurate.  

### BCheck Contributions

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives
