### PR TITLE
Check to detect when an endpoint support other content types than JSON.

### DIFF
--- a/other/supportForOtherContentTypesThanJson.bcheck
+++ b/other/supportForOtherContentTypesThanJson.bcheck
@@ -1,0 +1,31 @@
+metadata:
+    language: v2-beta
+    name: "Support for other content types than json detected"
+    description: "Check if an endpoint, accepting json data, support other interesting content types."
+    author: "Dominique Righetto"
+    tags: "active"
+
+run for each:
+    # Interesting content types that can bring new attacks vectors
+    content_type = "application/xml", "application/yaml"
+
+# The check only trigger for request containing a header "Content-Type" set to "application/json".
+# Sources:
+# https://portswigger.net/web-security/xxe
+# https://portswigger.net/web-security/ssrf
+# https://www.sourcery.ai/vulnerabilities/python-pyyaml-unsafe-load-rce
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/415
+given path then
+    if {base.request.headers} matches "(?i)Content-Type:\s+application\/json" then
+        send request called checkSupport:
+            replacing headers:
+                "Content-Type": `{content_type}`
+
+         if not( {checkSupport.response.status_code} is "415" ) then
+            report issue:
+                severity: info
+                confidence: firm
+                detail: `Endpoint support other content type than json: {content_type}.`
+                remediation: "Add a constraint on the endpoint to specify that only json content type is supported."
+        end if
+    end if


### PR DESCRIPTION
### Description

Hi,

This PR propose a BCheck to verify if an endpoint, supporting the content type JSON, also support other content types like XML/YAML. The usage context is an web API that normally consume JSON but also, via the web framework used, support XML/YAML. This can open new attack vectors like for example  [XML external entity (XXE) injection](https://portswigger.net/web-security/xxe).

Thank you for your feedback 😉

### Tests

It was tested in Burp Pro version **2025.12.4**:

<img width="629" height="298" alt="image" src="https://github.com/user-attachments/assets/462997d1-8da4-474e-9762-268109fb7929" />

### BCheck Contributions

* [x] BCheck compiles and executes as expected
* [x] BCheck contains appropriate metadata (name, version, author, description and appropriate tags)
* [x] Only .bcheck files have been added or modified
* [x] BCheck is in the appropriate folder
* [x] PR contains single or limited number of BChecks (Multiple PRs are preferred)
* [x] BCheck attempts to minimize false positives
